### PR TITLE
Add `condition` to `DataField` model

### DIFF
--- a/src/main/java/app/quickcase/sdk/spring/definition/model/DataField.java
+++ b/src/main/java/app/quickcase/sdk/spring/definition/model/DataField.java
@@ -20,7 +20,8 @@ public record DataField(
     Validation validation,
     Field.Display display,
     @NonNull @Singular("acl") Map<String, Integer> acl,
-    @NonNull String classification
+    @NonNull String classification,
+    String condition
 ) implements Field {
     @Builder
     public record Validation(


### PR DESCRIPTION
While conditions are not currently supported by root data fields, they are supported by complex member field. As complex member field reuse the `DataField` model, they thus require condition to be supported by `DataField`. It is conceivable that support for condition is added in the future for root field as well so it makes sense having optional support on `DataField`