### PR TITLE
Fix `[sourceFieldPath]` definition extraction

### DIFF
--- a/src/main/java/app/quickcase/sdk/spring/definition/DefinitionExtractor.java
+++ b/src/main/java/app/quickcase/sdk/spring/definition/DefinitionExtractor.java
@@ -70,7 +70,12 @@ public class DefinitionExtractor {
                                                 .name("Classification")
                                                 .label("Default record classification")
                                                 .build();
-            default -> throw new IllegalArgumentException("Path not supported in definition context: " + path);
+            // CaseLink metadata
+            case SOURCE_FIELD_PATH -> MetadataField.builder()
+                                                   .id(path.toString())
+                                                   .name("Link source field")
+                                                   .label("Path of the field from which the link originated")
+                                                   .build();
         };
     }
 

--- a/src/test/java/app/quickcase/sdk/spring/condition/validate/SemanticConditionValidatorTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/condition/validate/SemanticConditionValidatorTest.java
@@ -26,7 +26,8 @@ class SemanticConditionValidatorTest {
         var condition = new Condition(
                 new Criteria[][]{
                         new Criteria[]{
-                                Criteria.builder().path("complex1").build()
+                                Criteria.builder().path("complex1").build(),
+                                Criteria.builder().path("[sourceFieldPath]").build()
                         },
                         new Criteria[]{
                                 Criteria.builder().path("complex1.member1").build(),

--- a/src/test/java/app/quickcase/sdk/spring/definition/DefinitionExtractorTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/definition/DefinitionExtractorTest.java
@@ -143,19 +143,19 @@ class DefinitionExtractorTest {
             ));
         }
 
-        @ParameterizedTest
-        @ValueSource(strings = {
-                "[sourceFieldPath]"
-        })
-        @DisplayName("should throw error for paths not supported in definition context")
-        void shouldThrowErrorForPathsNotSupported(String path) {
+        @Test
+        @DisplayName("should return sourceFieldPath field")
+        void shouldReturnSourceFieldPathField() {
             var extractor = new DefinitionExtractor(recordType());
-            var error = assertThrows(
-                    IllegalArgumentException.class,
-                    () -> extractor.extractField(FieldPath.ofMetadata(path))
-            );
+            var field = extractor.extractField(FieldPath.ofMetadata("[sourceFieldPath]"));
 
-            assertThat(error.getMessage(), equalTo("Path not supported in definition context: " + path));
+            assertThat(field, equalTo(
+                    MetadataField.builder()
+                                 .id("[sourceFieldPath]")
+                                 .name("Link source field")
+                                 .label("Path of the field from which the link originated")
+                                 .build()
+            ));
         }
     }
 


### PR DESCRIPTION
Semantic condition validation relies on definition extractor returning a definition, hence something must be returned for `[sourceFieldPath]` to be considered valid