### PR TITLE
Add client ID extraction from JWT

### DIFF
--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthentication.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthentication.java
@@ -37,6 +37,8 @@ public abstract class QuickcaseAuthentication extends JwtAuthenticationToken {
 
     public abstract String getId();
 
+    public abstract Optional<String> getClientId();
+
     public abstract Set<String> getRoles();
 
     public abstract Set<String> getGroups();

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverter.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverter.java
@@ -5,9 +5,11 @@ import java.util.stream.Stream;
 
 import app.quickcase.sdk.spring.auth.claims.ClaimsParser;
 import app.quickcase.sdk.spring.auth.claims.JwtClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfo;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoExtractor;
 import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -20,16 +22,19 @@ import static java.util.stream.Collectors.toSet;
 public class QuickcaseAuthenticationConverter implements Converter<Jwt, QuickcaseAuthentication> {
     private static final String SCOPE_DELIMITER = " ";
 
+    private final JwtClientIdConverter clientIdConverter;
     protected final UserInfoExtractor userInfoExtractor;
     protected final String openidScope;
 
-    public QuickcaseAuthenticationConverter(UserInfoExtractor userInfoExtractor, String openidScope) {
+    public QuickcaseAuthenticationConverter(JwtClientIdConverter clientIdConverter, UserInfoExtractor userInfoExtractor, String openidScope) {
+        this.clientIdConverter = clientIdConverter;
         this.userInfoExtractor = userInfoExtractor;
         this.openidScope = openidScope;
     }
 
     @Override
-    public QuickcaseAuthentication convert(Jwt source) {
+    public QuickcaseAuthentication convert(@NonNull Jwt source) {
+        final String clientId = clientIdConverter.convert(source);
         final String scopeStr = source.getClaimAsString("scope");
 
         if (scopeStr == null) {
@@ -39,21 +44,21 @@ public class QuickcaseAuthenticationConverter implements Converter<Jwt, Quickcas
         final Set<String> scopes = Set.of(scopeStr.split(SCOPE_DELIMITER));
 
         if (scopes.contains(openidScope)) {
-            return userAuthentication(source, scopes);
+            return userAuthentication(source, scopes, clientId);
         }
 
-        return clientAuthentication(source, scopes);
+        return clientAuthentication(source, scopes, clientId);
     }
 
-    protected QuickcaseAuthentication clientAuthentication(Jwt jwt, Set<String> scopes) {
+    protected QuickcaseAuthentication clientAuthentication(Jwt jwt, Set<String> scopes, String clientId) {
         final String subject = jwt.getSubject();
-        return new QuickcaseClientAuthentication(jwt, subject, authorities(scopes), scopes);
+        return new QuickcaseClientAuthentication(jwt, subject, authorities(scopes), scopes, clientId);
     }
 
-    protected QuickcaseAuthentication userAuthentication(Jwt jwt, Set<String> scopes) {
+    protected QuickcaseAuthentication userAuthentication(Jwt jwt, Set<String> scopes, String clientId) {
         final ClaimsParser claims = new JwtClaimsParser(jwt);
         final UserInfo userInfo = userInfoExtractor.extract(claims);
-        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo);
+        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo, clientId);
     }
 
     protected final String prefixScope(String scope) {

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthentication.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthentication.java
@@ -7,6 +7,7 @@ import java.util.Set;
 import app.quickcase.sdk.spring.auth.organisation.OrganisationProfile;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfo;
 import lombok.NonNull;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -23,22 +24,31 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
 
     private final String subject;
     private final Set<String> roles;
+    @Nullable
+    private final String clientId;
 
     public QuickcaseClientAuthentication(
             @NonNull Jwt jwt,
             @NonNull String subject,
             @NonNull Collection<? extends GrantedAuthority> authorities,
-            @NonNull Set<String> roles
+            @NonNull Set<String> roles,
+            @Nullable String clientId
     ) {
         super(jwt, authorities);
         this.subject = subject;
         this.roles = roles;
+        this.clientId = clientId;
         this.setAuthenticated(true);
     }
 
     @Override
     public String getId() {
         return subject;
+    }
+
+    @Override
+    public Optional<String> getClientId() {
+        return Optional.ofNullable(clientId);
     }
 
     @Override

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseSecurityAutoConfiguration.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseSecurityAutoConfiguration.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import app.quickcase.sdk.spring.auth.claims.ClaimNamesProvider;
+import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoAuthenticationConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoExtractor;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoGateway;
@@ -48,6 +49,11 @@ public class QuickcaseSecurityAutoConfiguration {
         return new UserInfoGateway(new URI(oidcConfig.getUserInfoUri()), new RestTemplate());
     }
 
+    @Bean
+    public JwtClientIdConverter jwtClientIdConverter() {
+        return new JwtClientIdConverter();
+    }
+
     /**
      * @deprecated UserInfo parsing deprecated; scheduled for removal in v2.0.0
      */
@@ -56,21 +62,23 @@ public class QuickcaseSecurityAutoConfiguration {
     @ConditionalOnMissingBean(QuickcaseAuthenticationConverter.class)
     @ConditionalOnProperty(prefix = "quickcase.oidc", name = "mode", havingValue = "user-info", matchIfMissing = true)
     public UserInfoAuthenticationConverter createUserInfoAuthenticationConverter(
+            JwtClientIdConverter clientIdConverter,
             UserInfoGateway userInfoGateway,
             UserInfoExtractor userInfoExtractor,
             OidcConfig oidcConfig
     ) {
-        return new UserInfoAuthenticationConverter(userInfoGateway, userInfoExtractor, oidcConfig.getOpenidScope());
+        return new UserInfoAuthenticationConverter(clientIdConverter, userInfoGateway, userInfoExtractor, oidcConfig.getOpenidScope());
     }
 
     @Bean
     @ConditionalOnMissingBean(QuickcaseAuthenticationConverter.class)
     @ConditionalOnProperty(prefix = "quickcase.oidc", name = "mode", havingValue = "jwt-access-token")
     public QuickcaseAuthenticationConverter createAccessTokenAuthenticationConverter(
+            JwtClientIdConverter clientIdConverter,
             UserInfoExtractor userInfoExtractor,
             OidcConfig oidcConfig
     ) {
-        return new QuickcaseAuthenticationConverter(userInfoExtractor, oidcConfig.getOpenidScope());
+        return new QuickcaseAuthenticationConverter(clientIdConverter, userInfoExtractor, oidcConfig.getOpenidScope());
     }
 
     @Bean

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthentication.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthentication.java
@@ -7,6 +7,7 @@ import app.quickcase.sdk.spring.auth.organisation.OrganisationProfile;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfo;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -21,20 +22,29 @@ public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
     }
 
     private final UserInfo userInfo;
+    @Nullable
+    private final String clientId;
 
     public QuickcaseUserAuthentication(
             @NonNull Jwt jwt,
             @NonNull Set<GrantedAuthority> authorities,
-            @NonNull UserInfo userInfo
+            @NonNull UserInfo userInfo,
+            @Nullable String clientId
     ) {
         super(jwt, authorities);
         this.userInfo = userInfo;
+        this.clientId = clientId;
         this.setAuthenticated(true);
     }
 
     @Override
     public String getId() {
         return userInfo.getSubject();
+    }
+
+    @Override
+    public Optional<String> getClientId() {
+        return Optional.ofNullable(clientId);
     }
 
     @Override

--- a/src/main/java/app/quickcase/sdk/spring/auth/converters/JwtClientIdConverter.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/converters/JwtClientIdConverter.java
@@ -1,0 +1,34 @@
+package app.quickcase.sdk.spring.auth.converters;
+
+import java.util.List;
+import java.util.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Given a JWT token, attempt to extract the OAuth2 client ID from the claims `client_id` and `azp` in order of precedence.
+ * As the OAuth2/OpenID RFCs do not mandate either claim, a null value can be returned.
+ */
+@Slf4j
+public class JwtClientIdConverter implements Converter<Jwt, String> {
+    private static final List<String> LOOKUP_CLAIMS = List.of("client_id", "azp");
+
+    @Override
+    public String convert(@NonNull Jwt jwt) {
+        var claimName = getClaimName(jwt);
+
+        if (claimName.isPresent()) {
+            log.debug("Extracting client ID from claim {}", claimName.get());
+            return jwt.getClaimAsString(claimName.get());
+        }
+
+        return null;
+    }
+
+    private Optional<String> getClaimName(Jwt jwt) {
+        return LOOKUP_CLAIMS.stream().filter(claimName -> jwt.getClaim(claimName) != null).findFirst();
+    }
+}

--- a/src/main/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverter.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverter.java
@@ -8,6 +8,7 @@ import app.quickcase.sdk.spring.auth.QuickcaseAuthenticationConverter;
 import app.quickcase.sdk.spring.auth.QuickcaseUserAuthentication;
 import app.quickcase.sdk.spring.auth.claims.ClaimsParser;
 import app.quickcase.sdk.spring.auth.claims.JsonClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.jwt.Jwt;
 
@@ -20,13 +21,13 @@ public class UserInfoAuthenticationConverter extends QuickcaseAuthenticationConv
 
     private final UserInfoGateway userInfoGateway;
 
-    public UserInfoAuthenticationConverter(UserInfoGateway userInfoGateway, UserInfoExtractor userInfoExtractor, String openidScope) {
-        super(userInfoExtractor, openidScope);
+    public UserInfoAuthenticationConverter(JwtClientIdConverter clientIdConverter, UserInfoGateway userInfoGateway, UserInfoExtractor userInfoExtractor, String openidScope) {
+        super(clientIdConverter, userInfoExtractor, openidScope);
         this.userInfoGateway = userInfoGateway;
     }
 
     @Override
-    protected QuickcaseUserAuthentication userAuthentication(Jwt jwt, Set<String> scopes) {
+    protected QuickcaseUserAuthentication userAuthentication(Jwt jwt, Set<String> scopes, String clientId) {
         final String subject = jwt.getSubject();
         final ClaimsParser claims = new JsonClaimsParser(userInfoGateway.getClaims(jwt.getTokenValue()));
 
@@ -34,7 +35,7 @@ public class UserInfoAuthenticationConverter extends QuickcaseAuthenticationConv
 
         final UserInfo userInfo = userInfoExtractor.extract(claims);
 
-        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo);
+        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo, clientId);
     }
 
     /**

--- a/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverterTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverterTest.java
@@ -1,8 +1,10 @@
 package app.quickcase.sdk.spring.auth;
 
 import java.util.Arrays;
+import java.util.Optional;
 
 import app.quickcase.sdk.spring.auth.claims.JwtClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfo;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoExtractor;
 import app.quickcase.sdk.spring.auth.userinfo.UserPreferences;
@@ -11,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -23,7 +24,8 @@ import static org.mockito.Mockito.when;
 
 class QuickcaseAuthenticationConverterTest {
     private static final String ACCESS_TOKEN = "token123";
-    private static final String CLIENT_ID = "clientId";
+    private static final String SUBJECT = "subject-123";
+    private static final String CLIENT_ID = "client-123";
     private static final String SCOPE_1 = "scope-1";
     private static final String SCOPE_2 = "scope-2";
     private static final String USER_ID = "user-456";
@@ -34,10 +36,12 @@ class QuickcaseAuthenticationConverterTest {
     private static final String DEFAULT_JURISDICTION = "org-1";
 
     private QuickcaseAuthenticationConverter converter;
+    private JwtClientIdConverter clientIdConverter;
     private UserInfoExtractor userInfoExtractor;
 
     @BeforeEach
     void setUp() {
+        clientIdConverter = mock(JwtClientIdConverter.class);
         userInfoExtractor = mock(UserInfoExtractor.class);
 
         final UserPreferences preferences = UserPreferences.builder()
@@ -54,36 +58,47 @@ class QuickcaseAuthenticationConverterTest {
         when(userInfoExtractor.extract(ArgumentMatchers.any(JwtClaimsParser.class)))
                 .thenReturn(userInfo);
 
-        converter = new QuickcaseAuthenticationConverter(userInfoExtractor, OidcConfigDefault.OPENID_SCOPE);
+        converter = new QuickcaseAuthenticationConverter(clientIdConverter, userInfoExtractor, OidcConfigDefault.OPENID_SCOPE);
     }
 
     @Nested
     @DisplayName("when client credentials")
     class WhenClientCredentials {
 
-        private QuickcaseAuthentication clientAuthentication() {
-            final Jwt jwt = Jwt.withTokenValue(ACCESS_TOKEN)
-                               .header("alg", "HS256")
-                               .claim("sub", CLIENT_ID)
-                               .claim("scope", scopes(SCOPE_1, SCOPE_2))
-                               .claim("client_id", CLIENT_ID)
-                               .build();
+        Jwt jwt;
 
-            return converter.convert(jwt);
+        @BeforeEach
+        void setUp() {
+            jwt = Jwt.withTokenValue(ACCESS_TOKEN)
+                     .header("alg", "HS256")
+                     .claim("sub", SUBJECT)
+                     .claim("scope", scopes(SCOPE_1, SCOPE_2))
+                     .claim("client_id", CLIENT_ID)
+                     .build();
         }
 
         @Test
-        @DisplayName("should get ID from client")
-        void shouldGetIdFromClient() {
-            final QuickcaseAuthentication authentication = clientAuthentication();
+        @DisplayName("should get subject from token")
+        void shouldGetSubjectFromToken() {
+            final QuickcaseAuthentication authentication = converter.convert(jwt);;
 
-            assertThat(authentication.getId(), equalTo(CLIENT_ID));
+            assertThat(authentication.getId(), equalTo(SUBJECT));
+        }
+
+        @Test
+        @DisplayName("should get client ID from token")
+        void shouldGetClientIdFromToken() {
+            when(clientIdConverter.convert(jwt)).thenReturn(CLIENT_ID);
+
+            final QuickcaseAuthentication authentication = converter.convert(jwt);;
+
+            assertThat(authentication.getClientId(), equalTo(Optional.of(CLIENT_ID)));
         }
 
         @Test
         @DisplayName("should use scopes as prefixed authorities")
         void shouldUseScopesAsAuthorities() {
-            final QuickcaseAuthentication authentication = clientAuthentication();
+            final QuickcaseAuthentication authentication = converter.convert(jwt);;
 
             assertThat(authentication.getAuthorities(), containsInAnyOrder(authorities(
                     "SCOPE_" + SCOPE_1,
@@ -94,7 +109,7 @@ class QuickcaseAuthenticationConverterTest {
         @Test
         @DisplayName("should use scopes as roles")
         void shouldUseScopesAsRoles() {
-            final QuickcaseAuthentication authentication = clientAuthentication();
+            final QuickcaseAuthentication authentication = converter.convert(jwt);;
 
             assertThat(authentication.getRoles(), containsInAnyOrder(SCOPE_1, SCOPE_2));
         }
@@ -102,7 +117,7 @@ class QuickcaseAuthenticationConverterTest {
         @Test
         @DisplayName("should have original access token")
         void shouldHaveOriginalAccessToken() {
-            final QuickcaseAuthentication authentication = clientAuthentication();
+            final QuickcaseAuthentication authentication = converter.convert(jwt);;
 
             assertThat(authentication.getAccessToken(), equalTo(ACCESS_TOKEN));
         }
@@ -110,7 +125,7 @@ class QuickcaseAuthenticationConverterTest {
         @Test
         @DisplayName("should be client authentication")
         void shouldBeClientAuthentication() {
-            final QuickcaseAuthentication authentication = clientAuthentication();
+            final QuickcaseAuthentication authentication = converter.convert(jwt);;
 
             assertThat(authentication, instanceOf(QuickcaseClientAuthentication.class));
         }
@@ -120,28 +135,23 @@ class QuickcaseAuthenticationConverterTest {
     @DisplayName("when user credentials")
     class WhenUserCredentials {
 
-        private QuickcaseAuthentication userAuthentication() {
-            return userAuthentication(OidcConfigDefault.OPENID_SCOPE);
-        }
+        @Test
+        @DisplayName("should get client ID from token")
+        void shouldGetClientIdFromToken() {
+            var jwt = userJwt();
 
-        private QuickcaseAuthentication userAuthentication(String openidScope) {
-            final Jwt jwt = Jwt.withTokenValue(ACCESS_TOKEN)
-                               .header("alg", "HS256")
-                               .claim("scope", scopes(openidScope, SCOPE_2))
-                               .claim("client_id", CLIENT_ID)
-                               .claim("sub", USER_ID)
-                               .claim("name", USER_NAME)
-                               .claim("email", USER_EMAIL)
-                               .claim("app.quickcase.claims/roles", roles(ROLE_1, ROLE_2))
-                               .claim("app.quickcase.claims/default_jurisdiction", DEFAULT_JURISDICTION)
-                               .build();
-            return converter.convert(jwt);
+            when(clientIdConverter.convert(jwt)).thenReturn(CLIENT_ID);
+
+            var authentication = converter.convert(jwt);
+
+            assertThat(authentication.getClientId(), equalTo(Optional.of(CLIENT_ID)));
         }
 
         @Test
         @DisplayName("should combine prefixed scopes and roles as authorities")
         void shouldUseRolesAsAuthorities() {
-            final QuickcaseAuthentication authentication = userAuthentication();
+            var jwt = userJwt();
+            var authentication = converter.convert(jwt);
 
             assertThat(authentication.getAuthorities(), containsInAnyOrder(authorities(
                     "SCOPE_openid",
@@ -154,7 +164,8 @@ class QuickcaseAuthenticationConverterTest {
         @Test
         @DisplayName("should expose user roles")
         void shouldUseScopesAsRoles() {
-            final QuickcaseAuthentication authentication = userAuthentication();
+            var jwt = userJwt();
+            var authentication = converter.convert(jwt);
 
             assertThat(authentication.getRoles(), containsInAnyOrder(ROLE_1, ROLE_2));
         }
@@ -162,7 +173,8 @@ class QuickcaseAuthenticationConverterTest {
         @Test
         @DisplayName("should populate user authentication from access token")
         void shouldGetIdFromUser() {
-            final QuickcaseAuthentication authentication = userAuthentication();
+            var jwt = userJwt();
+            var authentication = converter.convert(jwt);
 
             assertThat(authentication, instanceOf(QuickcaseUserAuthentication.class));
             assertThat(authentication.getAccessToken(), equalTo(ACCESS_TOKEN));
@@ -177,11 +189,29 @@ class QuickcaseAuthenticationConverterTest {
         @Test
         @DisplayName("should accept custom scope for openid")
         void shouldAcceptCustomOpenIdScope() {
-            converter = new QuickcaseAuthenticationConverter(userInfoExtractor, "custom-openid");
+            converter = new QuickcaseAuthenticationConverter(clientIdConverter, userInfoExtractor, "custom-openid");
 
-            final QuickcaseAuthentication authentication = userAuthentication("custom-openid");
+            var jwt = userJwt("custom-openid");
+            var authentication = converter.convert(jwt);
 
             assertThat(authentication, instanceOf(QuickcaseUserAuthentication.class));
+        }
+
+        private Jwt userJwt() {
+            return userJwt(OidcConfigDefault.OPENID_SCOPE);
+        }
+
+        private Jwt userJwt(String openidScope) {
+            return Jwt.withTokenValue(ACCESS_TOKEN)
+                      .header("alg", "HS256")
+                      .claim("scope", scopes(openidScope, SCOPE_2))
+                      .claim("client_id", CLIENT_ID)
+                      .claim("sub", USER_ID)
+                      .claim("name", USER_NAME)
+                      .claim("email", USER_EMAIL)
+                      .claim("app.quickcase.claims/roles", roles(ROLE_1, ROLE_2))
+                      .claim("app.quickcase.claims/default_jurisdiction", DEFAULT_JURISDICTION)
+                      .build();
         }
     }
 

--- a/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthenticationTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthenticationTest.java
@@ -1,5 +1,6 @@
 package app.quickcase.sdk.spring.auth;
 
+import java.util.Optional;
 import java.util.Set;
 
 import app.quickcase.sdk.spring.auth.organisation.OrganisationProfile;
@@ -18,12 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class QuickcaseClientAuthenticationTest {
     private static final String ACCESS_TOKEN = "access-token-123";
     private static final String SUBJECT = "subject-123";
+    private static final String CLIENT_ID = "subject-123";
 
     private static final Jwt JWT = Jwt.withTokenValue(ACCESS_TOKEN)
                                       .header("alg", "HS256")
                                       .claim("sub", SUBJECT)
                                       .claim("scope", "SCOPE-1 SCOPE-2")
-                                      .claim("client_id", "client-123")
+                                      .claim("client_id", CLIENT_ID)
                                       .build();
 
     @Test
@@ -31,6 +33,13 @@ class QuickcaseClientAuthenticationTest {
     void getId() {
         final QuickcaseAuthentication auth = clientAuthentication();
         assertThat(auth.getId(), equalTo(SUBJECT));
+    }
+
+    @Test
+    @DisplayName("should have optional client ID")
+    void getClientId() {
+        final QuickcaseAuthentication auth = clientAuthentication();
+        assertThat(auth.getClientId(), equalTo(Optional.of(CLIENT_ID)));
     }
 
     @Test
@@ -106,6 +115,6 @@ class QuickcaseClientAuthenticationTest {
     private QuickcaseAuthentication clientAuthentication() {
         final Set<String> scopes = Set.of("ROLE-1", "ROLE-2");
         final Set<GrantedAuthority> authorities = scopes.stream().map(SimpleGrantedAuthority::new).collect(toSet());
-        return new QuickcaseClientAuthentication(JWT, SUBJECT, authorities, scopes);
+        return new QuickcaseClientAuthentication(JWT, SUBJECT, authorities, scopes, CLIENT_ID);
     }
 }

--- a/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthenticationTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthenticationTest.java
@@ -20,7 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class QuickcaseUserAuthenticationTest {
     private static final String ACCESS_TOKEN = "access-token-123";
-    private static final String USER_ID = "client-123";
+    private static final String CLIENT_ID = "client-123";
+    private static final String USER_ID = "user-123";
     private static final String USER_EMAIL = "test@test";
     private static final String USER_NAME = "Jean Paul";
 
@@ -35,9 +36,9 @@ class QuickcaseUserAuthenticationTest {
     @DisplayName("should enforce non-null fields")
     void shouldEnforceNonNullFields() {
         Assertions.assertAll(
-                () -> assertThrows(IllegalArgumentException.class, () -> new QuickcaseUserAuthentication(null, Set.of(), UserInfo.builder(USER_ID).build())),
-                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, null, UserInfo.builder(USER_ID).build())),
-                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, Set.of(), null))
+                () -> assertThrows(IllegalArgumentException.class, () -> new QuickcaseUserAuthentication(null, Set.of(), UserInfo.builder(USER_ID).build(), CLIENT_ID)),
+                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, null, UserInfo.builder(USER_ID).build(), CLIENT_ID)),
+                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, Set.of(), null, CLIENT_ID))
         );
     }
 
@@ -46,6 +47,13 @@ class QuickcaseUserAuthenticationTest {
     void getId() {
         final QuickcaseAuthentication auth = userAuthentication();
         assertThat(auth.getId(), equalTo(USER_ID));
+    }
+
+    @Test
+    @DisplayName("should have optional client ID")
+    void getClientId() {
+        final QuickcaseAuthentication auth = userAuthentication();
+        assertThat(auth.getClientId(), equalTo(Optional.of(CLIENT_ID)));
     }
 
     @Test
@@ -166,6 +174,6 @@ class QuickcaseUserAuthenticationTest {
                                           .organisationProfile("org-1", profile)
                                           .build();
 
-        return new QuickcaseUserAuthentication(JWT, authorities, userInfo);
+        return new QuickcaseUserAuthentication(JWT, authorities, userInfo, CLIENT_ID);
     }
 }

--- a/src/test/java/app/quickcase/sdk/spring/auth/converters/JwtClientIdConverterTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/converters/JwtClientIdConverterTest.java
@@ -1,0 +1,60 @@
+package app.quickcase.sdk.spring.auth.converters;
+
+import java.util.Optional;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("JwtClientIdConverter")
+class JwtClientIdConverterTest {
+
+    final JwtClientIdConverter converter = new JwtClientIdConverter();
+
+    @Test
+    @DisplayName("should return client ID from claim `client_id`")
+    void shouldReturnClientIdFromClaimClientId() {
+        var jwt = jwtBuilder().claim("client_id", "aClientId").build();
+
+        assertThat(converter.convert(jwt), is("aClientId"));
+    }
+
+    @Test
+    @DisplayName("should return client ID from claim `azp`")
+    void shouldReturnClientIdFromClaimAzp() {
+        var jwt = jwtBuilder().claim("azp", "aClientId").build();
+
+        assertThat(converter.convert(jwt), is("aClientId"));
+    }
+
+    @Test
+    @DisplayName("should give precedence to claim `client_id` vs `azp`")
+    void shouldGivePrecedenceToClaimClientId() {
+        var jwt = jwtBuilder().claim("azp", "incorrect")
+                              .claim("client_id", "aClientId")
+                              .build();
+
+        assertThat(converter.convert(jwt), is("aClientId"));
+    }
+
+    @Test
+    @DisplayName("should return empty when no relevant claim found")
+    void shouldReturnEmptyWhenNoRelevantClaimFound() {
+        var jwt = jwtBuilder().build();
+
+        assertThat(converter.convert(jwt), is(nullValue()));
+    }
+
+    private Jwt.Builder jwtBuilder() {
+        return Jwt.withTokenValue("token-value")
+                   .header("alg", "none")
+                   .claim("claim1", "value1");
+    }
+
+}

--- a/src/test/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverterTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverterTest.java
@@ -9,6 +9,7 @@ import app.quickcase.sdk.spring.auth.QuickcaseAuthentication;
 import app.quickcase.sdk.spring.auth.QuickcaseUserAuthentication;
 import app.quickcase.sdk.spring.auth.SecurityClassification;
 import app.quickcase.sdk.spring.auth.claims.JsonClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.organisation.OrganisationProfile;
 import com.fasterxml.jackson.databind.node.TextNode;
 import org.hamcrest.Matchers;
@@ -38,16 +39,18 @@ class UserInfoAuthenticationConverterTest {
     private static final String ROLE_1 = "role-1";
     private static final String ROLE_2 = "role-2";
 
+    private JwtClientIdConverter clientIdConverter;
     private UserInfoGateway userInfoGateway;
     private UserInfoExtractor userInfoExtractor;
     private UserInfoAuthenticationConverter converter;
 
     @BeforeEach
     void setUp() {
+        clientIdConverter = mock(JwtClientIdConverter.class);
         userInfoGateway = mock(UserInfoGateway.class);
         userInfoExtractor = mock(UserInfoExtractor.class);
 
-        converter = new UserInfoAuthenticationConverter(userInfoGateway, userInfoExtractor, OidcConfigDefault.OPENID_SCOPE);
+        converter = new UserInfoAuthenticationConverter(clientIdConverter, userInfoGateway, userInfoExtractor, OidcConfigDefault.OPENID_SCOPE);
     }
 
     @Nested
@@ -169,7 +172,7 @@ class UserInfoAuthenticationConverterTest {
         @Test
         @DisplayName("should accept custom scope for openid")
         void shouldAcceptCustomOpenIdScope() {
-            converter = new UserInfoAuthenticationConverter(userInfoGateway, userInfoExtractor, "custom-openid");
+            converter = new UserInfoAuthenticationConverter(clientIdConverter, userInfoGateway, userInfoExtractor, "custom-openid");
 
             final QuickcaseAuthentication authentication = userAuthentication("custom-openid");
 


### PR DESCRIPTION
Client ID may be null as not mandated by OAuth2 or OpenID RFCs, extraction is a best effort.
There's also confusion around the claim used to convey the client ID, this implementation favours the use of `client_id` with a fallback to `azp`.

Duplication between `QuickcaseClientAuthentication` and `QuickcaseUserAuthentication` is getting significant, we should consider merging both into the parent `QuickcaseAuthentication`.