### PR TITLE
Add account claim

### DIFF
--- a/src/main/java/app/quickcase/sdk/spring/auth/OidcConfig.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/OidcConfig.java
@@ -75,6 +75,7 @@ public class OidcConfig {
         String sub;
         String name;
         String email;
+        String account;
         String roles;
         String groups;
         String organisations;
@@ -85,6 +86,7 @@ public class OidcConfig {
         public ClaimNames(@DefaultValue(SUB) String sub,
                           @DefaultValue(NAME) String name,
                           @DefaultValue(EMAIL) String email,
+                          @DefaultValue(QC_ACCOUNT) String account,
                           @DefaultValue(QC_ROLES) String roles,
                           @DefaultValue(QC_GROUPS) String groups,
                           @DefaultValue(QC_ORGANISATIONS) String organisations,
@@ -94,6 +96,7 @@ public class OidcConfig {
             this.sub = sub;
             this.name = name;
             this.email = email;
+            this.account = account;
             this.roles = roles;
             this.groups = groups;
             this.organisations = organisations;

--- a/src/main/java/app/quickcase/sdk/spring/auth/OidcConfigDefault.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/OidcConfigDefault.java
@@ -13,6 +13,7 @@ public interface OidcConfigDefault {
         String NAME = "name";
         String EMAIL = "email";
         // Private claims
+        String QC_ACCOUNT = NAMESPACE + "account";
         String QC_ROLES = NAMESPACE + "roles";
         String QC_GROUPS = NAMESPACE + "groups";
         String QC_ORGANISATIONS = NAMESPACE + "organisations";

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthentication.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthentication.java
@@ -39,6 +39,8 @@ public abstract class QuickcaseAuthentication extends JwtAuthenticationToken {
 
     public abstract Optional<String> getClientId();
 
+    public abstract String getAccount();
+
     public abstract Set<String> getRoles();
 
     public abstract Set<String> getGroups();

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverter.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverter.java
@@ -5,6 +5,7 @@ import java.util.stream.Stream;
 
 import app.quickcase.sdk.spring.auth.claims.ClaimsParser;
 import app.quickcase.sdk.spring.auth.claims.JwtClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtAccountConverter;
 import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfo;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoExtractor;
@@ -23,11 +24,18 @@ public class QuickcaseAuthenticationConverter implements Converter<Jwt, Quickcas
     private static final String SCOPE_DELIMITER = " ";
 
     private final JwtClientIdConverter clientIdConverter;
+    private final JwtAccountConverter accountConverter;
     protected final UserInfoExtractor userInfoExtractor;
     protected final String openidScope;
 
-    public QuickcaseAuthenticationConverter(JwtClientIdConverter clientIdConverter, UserInfoExtractor userInfoExtractor, String openidScope) {
+    public QuickcaseAuthenticationConverter(
+            JwtClientIdConverter clientIdConverter,
+            JwtAccountConverter accountConverter,
+            UserInfoExtractor userInfoExtractor,
+            String openidScope
+    ) {
         this.clientIdConverter = clientIdConverter;
+        this.accountConverter = accountConverter;
         this.userInfoExtractor = userInfoExtractor;
         this.openidScope = openidScope;
     }
@@ -35,6 +43,8 @@ public class QuickcaseAuthenticationConverter implements Converter<Jwt, Quickcas
     @Override
     public QuickcaseAuthentication convert(@NonNull Jwt source) {
         final String clientId = clientIdConverter.convert(source);
+        final String account = accountConverter.convert(source);
+
         final String scopeStr = source.getClaimAsString("scope");
 
         if (scopeStr == null) {
@@ -44,21 +54,21 @@ public class QuickcaseAuthenticationConverter implements Converter<Jwt, Quickcas
         final Set<String> scopes = Set.of(scopeStr.split(SCOPE_DELIMITER));
 
         if (scopes.contains(openidScope)) {
-            return userAuthentication(source, scopes, clientId);
+            return userAuthentication(source, scopes, clientId, account);
         }
 
-        return clientAuthentication(source, scopes, clientId);
+        return clientAuthentication(source, scopes, clientId, account);
     }
 
-    protected QuickcaseAuthentication clientAuthentication(Jwt jwt, Set<String> scopes, String clientId) {
+    protected QuickcaseAuthentication clientAuthentication(Jwt jwt, Set<String> scopes, String clientId, String account) {
         final String subject = jwt.getSubject();
-        return new QuickcaseClientAuthentication(jwt, subject, authorities(scopes), scopes, clientId);
+        return new QuickcaseClientAuthentication(jwt, subject, authorities(scopes), scopes, clientId, account);
     }
 
-    protected QuickcaseAuthentication userAuthentication(Jwt jwt, Set<String> scopes, String clientId) {
+    protected QuickcaseAuthentication userAuthentication(Jwt jwt, Set<String> scopes, String clientId, String account) {
         final ClaimsParser claims = new JwtClaimsParser(jwt);
         final UserInfo userInfo = userInfoExtractor.extract(claims);
-        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo, clientId);
+        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo, clientId, account);
     }
 
     protected final String prefixScope(String scope) {

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthentication.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthentication.java
@@ -26,18 +26,22 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
     private final Set<String> roles;
     @Nullable
     private final String clientId;
+    @Nullable
+    private final String account;
 
     public QuickcaseClientAuthentication(
             @NonNull Jwt jwt,
             @NonNull String subject,
             @NonNull Collection<? extends GrantedAuthority> authorities,
             @NonNull Set<String> roles,
-            @Nullable String clientId
+            @Nullable String clientId,
+            @Nullable String account
     ) {
         super(jwt, authorities);
         this.subject = subject;
         this.roles = roles;
         this.clientId = clientId;
+        this.account = account;
         this.setAuthenticated(true);
     }
 
@@ -49,6 +53,11 @@ public class QuickcaseClientAuthentication extends QuickcaseAuthentication {
     @Override
     public Optional<String> getClientId() {
         return Optional.ofNullable(clientId);
+    }
+
+    @Override
+    public String getAccount() {
+        return account;
     }
 
     @Override

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseSecurityAutoConfiguration.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseSecurityAutoConfiguration.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 
 import app.quickcase.sdk.spring.auth.claims.ClaimNamesProvider;
+import app.quickcase.sdk.spring.auth.converters.JwtAccountConverter;
 import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoAuthenticationConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoExtractor;
@@ -54,6 +55,11 @@ public class QuickcaseSecurityAutoConfiguration {
         return new JwtClientIdConverter();
     }
 
+    @Bean
+    public JwtAccountConverter jwtAccountConverter(OidcConfig oidcConfig) {
+        return new JwtAccountConverter(oidcConfig.getClaims().getNames().getAccount());
+    }
+
     /**
      * @deprecated UserInfo parsing deprecated; scheduled for removal in v2.0.0
      */
@@ -63,11 +69,18 @@ public class QuickcaseSecurityAutoConfiguration {
     @ConditionalOnProperty(prefix = "quickcase.oidc", name = "mode", havingValue = "user-info", matchIfMissing = true)
     public UserInfoAuthenticationConverter createUserInfoAuthenticationConverter(
             JwtClientIdConverter clientIdConverter,
+            JwtAccountConverter accountConverter,
             UserInfoGateway userInfoGateway,
             UserInfoExtractor userInfoExtractor,
             OidcConfig oidcConfig
     ) {
-        return new UserInfoAuthenticationConverter(clientIdConverter, userInfoGateway, userInfoExtractor, oidcConfig.getOpenidScope());
+        return new UserInfoAuthenticationConverter(
+                clientIdConverter,
+                accountConverter,
+                userInfoGateway,
+                userInfoExtractor,
+                oidcConfig.getOpenidScope()
+        );
     }
 
     @Bean
@@ -75,10 +88,16 @@ public class QuickcaseSecurityAutoConfiguration {
     @ConditionalOnProperty(prefix = "quickcase.oidc", name = "mode", havingValue = "jwt-access-token")
     public QuickcaseAuthenticationConverter createAccessTokenAuthenticationConverter(
             JwtClientIdConverter clientIdConverter,
+            JwtAccountConverter accountConverter,
             UserInfoExtractor userInfoExtractor,
             OidcConfig oidcConfig
     ) {
-        return new QuickcaseAuthenticationConverter(clientIdConverter, userInfoExtractor, oidcConfig.getOpenidScope());
+        return new QuickcaseAuthenticationConverter(
+                clientIdConverter,
+                accountConverter,
+                userInfoExtractor,
+                oidcConfig.getOpenidScope()
+        );
     }
 
     @Bean

--- a/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthentication.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthentication.java
@@ -24,16 +24,20 @@ public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
     private final UserInfo userInfo;
     @Nullable
     private final String clientId;
+    @Nullable
+    private final String account;
 
     public QuickcaseUserAuthentication(
             @NonNull Jwt jwt,
             @NonNull Set<GrantedAuthority> authorities,
             @NonNull UserInfo userInfo,
-            @Nullable String clientId
+            @Nullable String clientId,
+            @Nullable String account
     ) {
         super(jwt, authorities);
         this.userInfo = userInfo;
         this.clientId = clientId;
+        this.account = account;
         this.setAuthenticated(true);
     }
 
@@ -45,6 +49,11 @@ public class QuickcaseUserAuthentication extends QuickcaseAuthentication {
     @Override
     public Optional<String> getClientId() {
         return Optional.ofNullable(clientId);
+    }
+
+    @Override
+    public String getAccount() {
+        return account;
     }
 
     @Override

--- a/src/main/java/app/quickcase/sdk/spring/auth/claims/ClaimNamesProvider.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/claims/ClaimNamesProvider.java
@@ -10,6 +10,7 @@ public class ClaimNamesProvider {
     private final String sub;
     private final String name;
     private final String email;
+    private final String account;
     private final String roles;
     private final String groups;
     private final String organisations;
@@ -24,6 +25,7 @@ public class ClaimNamesProvider {
         this.sub = names.getSub();
         this.name = names.getName();
         this.email = names.getEmail();
+        this.account = names.getAccount();
         this.roles = names.getRoles();
         this.groups = names.getGroups();
         this.organisations = names.getOrganisations();
@@ -42,6 +44,10 @@ public class ClaimNamesProvider {
 
     public String email() {
         return email;
+    }
+
+    public String account() {
+        return prefix + account;
     }
 
     public String roles() {

--- a/src/main/java/app/quickcase/sdk/spring/auth/converters/JwtAccountConverter.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/converters/JwtAccountConverter.java
@@ -1,0 +1,32 @@
+package app.quickcase.sdk.spring.auth.converters;
+
+import java.util.List;
+import java.util.Optional;
+
+import app.quickcase.sdk.spring.auth.OidcConfigDefault;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+/**
+ * Given a JWT token, attempt to extract the account identifier.
+ * As this is a private claim, it cannot be mandated and could be null.
+ */
+@Slf4j
+public class JwtAccountConverter implements Converter<Jwt, String> {
+    private final String accountClaim;
+
+    public JwtAccountConverter() {
+        accountClaim = OidcConfigDefault.Claims.QC_ACCOUNT;
+    }
+
+    public JwtAccountConverter(String accountClaim) {
+        this.accountClaim = accountClaim;
+    }
+
+    @Override
+    public String convert(@NonNull Jwt jwt) {
+        return jwt.getClaimAsString(accountClaim);
+    }
+}

--- a/src/main/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverter.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverter.java
@@ -8,6 +8,7 @@ import app.quickcase.sdk.spring.auth.QuickcaseAuthenticationConverter;
 import app.quickcase.sdk.spring.auth.QuickcaseUserAuthentication;
 import app.quickcase.sdk.spring.auth.claims.ClaimsParser;
 import app.quickcase.sdk.spring.auth.claims.JsonClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtAccountConverter;
 import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.oauth2.jwt.Jwt;
@@ -21,13 +22,19 @@ public class UserInfoAuthenticationConverter extends QuickcaseAuthenticationConv
 
     private final UserInfoGateway userInfoGateway;
 
-    public UserInfoAuthenticationConverter(JwtClientIdConverter clientIdConverter, UserInfoGateway userInfoGateway, UserInfoExtractor userInfoExtractor, String openidScope) {
-        super(clientIdConverter, userInfoExtractor, openidScope);
+    public UserInfoAuthenticationConverter(
+            JwtClientIdConverter clientIdConverter,
+            JwtAccountConverter accountConverter,
+            UserInfoGateway userInfoGateway,
+            UserInfoExtractor userInfoExtractor,
+            String openidScope
+    ) {
+        super(clientIdConverter, accountConverter, userInfoExtractor, openidScope);
         this.userInfoGateway = userInfoGateway;
     }
 
     @Override
-    protected QuickcaseUserAuthentication userAuthentication(Jwt jwt, Set<String> scopes, String clientId) {
+    protected QuickcaseUserAuthentication userAuthentication(Jwt jwt, Set<String> scopes, String clientId, String account) {
         final String subject = jwt.getSubject();
         final ClaimsParser claims = new JsonClaimsParser(userInfoGateway.getClaims(jwt.getTokenValue()));
 
@@ -35,7 +42,7 @@ public class UserInfoAuthenticationConverter extends QuickcaseAuthenticationConv
 
         final UserInfo userInfo = userInfoExtractor.extract(claims);
 
-        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo, clientId);
+        return new QuickcaseUserAuthentication(jwt, authorities(scopes, userInfo.getRoles()), userInfo, clientId, account);
     }
 
     /**

--- a/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverterTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseAuthenticationConverterTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import app.quickcase.sdk.spring.auth.claims.JwtClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtAccountConverter;
 import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfo;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfoExtractor;
@@ -26,6 +27,7 @@ class QuickcaseAuthenticationConverterTest {
     private static final String ACCESS_TOKEN = "token123";
     private static final String SUBJECT = "subject-123";
     private static final String CLIENT_ID = "client-123";
+    private static final String ACCOUNT = "account-123";
     private static final String SCOPE_1 = "scope-1";
     private static final String SCOPE_2 = "scope-2";
     private static final String USER_ID = "user-456";
@@ -37,11 +39,13 @@ class QuickcaseAuthenticationConverterTest {
 
     private QuickcaseAuthenticationConverter converter;
     private JwtClientIdConverter clientIdConverter;
+    private JwtAccountConverter accountConverter;
     private UserInfoExtractor userInfoExtractor;
 
     @BeforeEach
     void setUp() {
         clientIdConverter = mock(JwtClientIdConverter.class);
+        accountConverter = mock(JwtAccountConverter.class);
         userInfoExtractor = mock(UserInfoExtractor.class);
 
         final UserPreferences preferences = UserPreferences.builder()
@@ -58,7 +62,7 @@ class QuickcaseAuthenticationConverterTest {
         when(userInfoExtractor.extract(ArgumentMatchers.any(JwtClaimsParser.class)))
                 .thenReturn(userInfo);
 
-        converter = new QuickcaseAuthenticationConverter(clientIdConverter, userInfoExtractor, OidcConfigDefault.OPENID_SCOPE);
+        converter = new QuickcaseAuthenticationConverter(clientIdConverter, accountConverter, userInfoExtractor, OidcConfigDefault.OPENID_SCOPE);
     }
 
     @Nested
@@ -93,6 +97,16 @@ class QuickcaseAuthenticationConverterTest {
             final QuickcaseAuthentication authentication = converter.convert(jwt);;
 
             assertThat(authentication.getClientId(), equalTo(Optional.of(CLIENT_ID)));
+        }
+
+        @Test
+        @DisplayName("should get account from token")
+        void shouldGetAccountFromToken() {
+            when(accountConverter.convert(jwt)).thenReturn(ACCOUNT);
+
+            var authentication = converter.convert(jwt);
+
+            assertThat(authentication.getAccount(), is(ACCOUNT));
         }
 
         @Test
@@ -148,6 +162,18 @@ class QuickcaseAuthenticationConverterTest {
         }
 
         @Test
+        @DisplayName("should get account from token")
+        void shouldGetAccountFromToken() {
+            var jwt = userJwt();
+
+            when(accountConverter.convert(jwt)).thenReturn(ACCOUNT);
+
+            var authentication = converter.convert(jwt);
+
+            assertThat(authentication.getAccount(), is(ACCOUNT));
+        }
+
+        @Test
         @DisplayName("should combine prefixed scopes and roles as authorities")
         void shouldUseRolesAsAuthorities() {
             var jwt = userJwt();
@@ -189,7 +215,7 @@ class QuickcaseAuthenticationConverterTest {
         @Test
         @DisplayName("should accept custom scope for openid")
         void shouldAcceptCustomOpenIdScope() {
-            converter = new QuickcaseAuthenticationConverter(clientIdConverter, userInfoExtractor, "custom-openid");
+            converter = new QuickcaseAuthenticationConverter(clientIdConverter, accountConverter, userInfoExtractor, "custom-openid");
 
             var jwt = userJwt("custom-openid");
             var authentication = converter.convert(jwt);

--- a/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthenticationTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseClientAuthenticationTest.java
@@ -19,7 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 class QuickcaseClientAuthenticationTest {
     private static final String ACCESS_TOKEN = "access-token-123";
     private static final String SUBJECT = "subject-123";
-    private static final String CLIENT_ID = "subject-123";
+    private static final String CLIENT_ID = "client-123";
+    private static final String ACCOUNT = "account-123";
 
     private static final Jwt JWT = Jwt.withTokenValue(ACCESS_TOKEN)
                                       .header("alg", "HS256")
@@ -40,6 +41,13 @@ class QuickcaseClientAuthenticationTest {
     void getClientId() {
         final QuickcaseAuthentication auth = clientAuthentication();
         assertThat(auth.getClientId(), equalTo(Optional.of(CLIENT_ID)));
+    }
+
+    @Test
+    @DisplayName("should have account")
+    void getAccount() {
+        final QuickcaseAuthentication auth = clientAuthentication();
+        assertThat(auth.getAccount(), equalTo(ACCOUNT));
     }
 
     @Test
@@ -115,6 +123,6 @@ class QuickcaseClientAuthenticationTest {
     private QuickcaseAuthentication clientAuthentication() {
         final Set<String> scopes = Set.of("ROLE-1", "ROLE-2");
         final Set<GrantedAuthority> authorities = scopes.stream().map(SimpleGrantedAuthority::new).collect(toSet());
-        return new QuickcaseClientAuthentication(JWT, SUBJECT, authorities, scopes, CLIENT_ID);
+        return new QuickcaseClientAuthentication(JWT, SUBJECT, authorities, scopes, CLIENT_ID, ACCOUNT);
     }
 }

--- a/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthenticationTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/QuickcaseUserAuthenticationTest.java
@@ -21,6 +21,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class QuickcaseUserAuthenticationTest {
     private static final String ACCESS_TOKEN = "access-token-123";
     private static final String CLIENT_ID = "client-123";
+    private static final String ACCOUNT = "account-123";
     private static final String USER_ID = "user-123";
     private static final String USER_EMAIL = "test@test";
     private static final String USER_NAME = "Jean Paul";
@@ -36,9 +37,9 @@ class QuickcaseUserAuthenticationTest {
     @DisplayName("should enforce non-null fields")
     void shouldEnforceNonNullFields() {
         Assertions.assertAll(
-                () -> assertThrows(IllegalArgumentException.class, () -> new QuickcaseUserAuthentication(null, Set.of(), UserInfo.builder(USER_ID).build(), CLIENT_ID)),
-                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, null, UserInfo.builder(USER_ID).build(), CLIENT_ID)),
-                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, Set.of(), null, CLIENT_ID))
+                () -> assertThrows(IllegalArgumentException.class, () -> new QuickcaseUserAuthentication(null, Set.of(), UserInfo.builder(USER_ID).build(), CLIENT_ID, ACCOUNT)),
+                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, null, UserInfo.builder(USER_ID).build(), CLIENT_ID, ACCOUNT)),
+                () -> assertThrows(NullPointerException.class, () -> new QuickcaseUserAuthentication(JWT, Set.of(), null, CLIENT_ID, ACCOUNT))
         );
     }
 
@@ -54,6 +55,13 @@ class QuickcaseUserAuthenticationTest {
     void getClientId() {
         final QuickcaseAuthentication auth = userAuthentication();
         assertThat(auth.getClientId(), equalTo(Optional.of(CLIENT_ID)));
+    }
+
+    @Test
+    @DisplayName("should have account")
+    void getAccount() {
+        final QuickcaseAuthentication auth = userAuthentication();
+        assertThat(auth.getAccount(), equalTo(ACCOUNT));
     }
 
     @Test
@@ -174,6 +182,6 @@ class QuickcaseUserAuthenticationTest {
                                           .organisationProfile("org-1", profile)
                                           .build();
 
-        return new QuickcaseUserAuthentication(JWT, authorities, userInfo, CLIENT_ID);
+        return new QuickcaseUserAuthentication(JWT, authorities, userInfo, CLIENT_ID, ACCOUNT);
     }
 }

--- a/src/test/java/app/quickcase/sdk/spring/auth/claims/ClaimNamesProviderTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/claims/ClaimNamesProviderTest.java
@@ -13,6 +13,7 @@ class ClaimNamesProviderTest {
     private static final String SUB = "conf-sub";
     private static final String NAME = "conf-name";
     private static final String EMAIL = "conf-email";
+    private static final String ACCOUNT = "conf-account";
     private static final String ROLES = "conf-roles";
     private static final String GROUPS = "conf-groups";
     private static final String ORGS = "conf-orgs";
@@ -23,15 +24,18 @@ class ClaimNamesProviderTest {
     @Test
     @DisplayName("should provide claim names as configured")
     void shouldProvideConfiguredClaims() {
-        final OidcConfig.ClaimNames claimNames = new OidcConfig.ClaimNames(SUB,
-                                                                           NAME,
-                                                                           EMAIL,
-                                                                           ROLES,
-                                                                           GROUPS,
-                                                                           ORGS,
-                                                                           DEF_JURISDICTION,
-                                                                           DEF_CASE_TYPE,
-                                                                           DEF_STATE);
+        final OidcConfig.ClaimNames claimNames = new OidcConfig.ClaimNames(
+                SUB,
+                NAME,
+                EMAIL,
+                ACCOUNT,
+                ROLES,
+                GROUPS,
+                ORGS,
+                DEF_JURISDICTION,
+                DEF_CASE_TYPE,
+                DEF_STATE
+        );
         final OidcConfig.Claims claimsConfig = new OidcConfig.Claims(PREFIX, claimNames);
 
         final ClaimNamesProvider claimNamesProvider = new ClaimNamesProvider(claimsConfig);
@@ -40,6 +44,7 @@ class ClaimNamesProviderTest {
                 () -> assertThat(claimNamesProvider.sub(), equalTo(SUB)),
                 () -> assertThat(claimNamesProvider.name(), equalTo(NAME)),
                 () -> assertThat(claimNamesProvider.email(), equalTo(EMAIL)),
+                () -> assertThat(claimNamesProvider.account(), equalTo(PREFIX + ACCOUNT)),
                 () -> assertThat(claimNamesProvider.roles(), equalTo(PREFIX + ROLES)),
                 () -> assertThat(claimNamesProvider.groups(), equalTo(PREFIX + GROUPS)),
                 () -> assertThat(claimNamesProvider.organisations(), equalTo(PREFIX + ORGS)),

--- a/src/test/java/app/quickcase/sdk/spring/auth/converters/JwtAccountConverterTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/converters/JwtAccountConverterTest.java
@@ -1,0 +1,48 @@
+package app.quickcase.sdk.spring.auth.converters;
+
+import app.quickcase.sdk.spring.auth.OidcConfigDefault;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+class JwtAccountConverterTest {
+
+    private final String CUSTOM_ACCOUNT_CLAIM = "accountClaim";
+
+    private final JwtAccountConverter defaultAccountConverter = new JwtAccountConverter();
+    private final JwtAccountConverter customAccountConverter = new JwtAccountConverter(CUSTOM_ACCOUNT_CLAIM);
+
+    @Test
+    @DisplayName("should return account claim as string using default claim name")
+    void shouldReturnAccountClaimAsStringUsingDefaultClaimName() {
+        var jwt = jwtBuilder().claim(OidcConfigDefault.Claims.QC_ACCOUNT, "account-123").build();
+
+        assertThat(defaultAccountConverter.convert(jwt), is("account-123"));
+    }
+
+    @Test
+    @DisplayName("should return account claim as string when found")
+    void shouldReturnAccountClaimAsStringWhenFound() {
+        var jwt = jwtBuilder().claim(CUSTOM_ACCOUNT_CLAIM, "account-123").build();
+
+        assertThat(customAccountConverter.convert(jwt), is("account-123"));
+    }
+
+    @Test
+    @DisplayName("should return null when jwt does not contain account claim")
+    void shouldReturnNullWhenJwtDoesNotContainAccountClaim() {
+        var jwt = jwtBuilder().build();
+
+        assertThat(customAccountConverter.convert(jwt), is(nullValue()));
+    }
+
+    private Jwt.Builder jwtBuilder() {
+        return Jwt.withTokenValue("token-value")
+                  .header("alg", "none")
+                  .claim("claim1", "value1");
+    }
+}

--- a/src/test/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverterTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoAuthenticationConverterTest.java
@@ -9,6 +9,7 @@ import app.quickcase.sdk.spring.auth.QuickcaseAuthentication;
 import app.quickcase.sdk.spring.auth.QuickcaseUserAuthentication;
 import app.quickcase.sdk.spring.auth.SecurityClassification;
 import app.quickcase.sdk.spring.auth.claims.JsonClaimsParser;
+import app.quickcase.sdk.spring.auth.converters.JwtAccountConverter;
 import app.quickcase.sdk.spring.auth.converters.JwtClientIdConverter;
 import app.quickcase.sdk.spring.auth.organisation.OrganisationProfile;
 import com.fasterxml.jackson.databind.node.TextNode;
@@ -40,6 +41,7 @@ class UserInfoAuthenticationConverterTest {
     private static final String ROLE_2 = "role-2";
 
     private JwtClientIdConverter clientIdConverter;
+    private JwtAccountConverter accountConverter;
     private UserInfoGateway userInfoGateway;
     private UserInfoExtractor userInfoExtractor;
     private UserInfoAuthenticationConverter converter;
@@ -47,10 +49,17 @@ class UserInfoAuthenticationConverterTest {
     @BeforeEach
     void setUp() {
         clientIdConverter = mock(JwtClientIdConverter.class);
+        accountConverter = mock(JwtAccountConverter.class);
         userInfoGateway = mock(UserInfoGateway.class);
         userInfoExtractor = mock(UserInfoExtractor.class);
 
-        converter = new UserInfoAuthenticationConverter(clientIdConverter, userInfoGateway, userInfoExtractor, OidcConfigDefault.OPENID_SCOPE);
+        converter = new UserInfoAuthenticationConverter(
+                clientIdConverter,
+                accountConverter,
+                userInfoGateway,
+                userInfoExtractor,
+                OidcConfigDefault.OPENID_SCOPE
+        );
     }
 
     @Nested
@@ -172,7 +181,7 @@ class UserInfoAuthenticationConverterTest {
         @Test
         @DisplayName("should accept custom scope for openid")
         void shouldAcceptCustomOpenIdScope() {
-            converter = new UserInfoAuthenticationConverter(clientIdConverter, userInfoGateway, userInfoExtractor, "custom-openid");
+            converter = new UserInfoAuthenticationConverter(clientIdConverter, accountConverter, userInfoGateway, userInfoExtractor, "custom-openid");
 
             final QuickcaseAuthentication authentication = userAuthentication("custom-openid");
 

--- a/src/test/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoExtractorTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/userinfo/UserInfoExtractorTest.java
@@ -29,6 +29,7 @@ class UserInfoExtractorTest {
     private static final String CLAIM_SUB = "conf-sub";
     private static final String CLAIM_NAME = "conf-name";
     private static final String CLAIM_EMAIL = "conf-email";
+    private static final String CLAIM_ACCOUNT = "conf-account";
     private static final String CLAIM_ROLES = "conf-roles";
     private static final String CLAIM_GROUPS = "conf-groups";
     private static final String CLAIM_ORGS = "conf-orgs";
@@ -36,6 +37,7 @@ class UserInfoExtractorTest {
     private static final String CLAIM_DEF_CASE_TYPE = "conf-case-type";
     private static final String CLAIM_DEF_STATE = "conf-state";
 
+    private static final String USER_ACCOUNT = "account-123";
     private static final String USER_APP_ROLES = "role1,role2";
     private static final String USER_GROUPS = "group1,group2";
     private static final String USER_ID = "eec55037-bac7-46b4-9849-f063e627e4f3";
@@ -132,6 +134,7 @@ class UserInfoExtractorTest {
         claims.put(CLAIM_SUB, textNode(USER_ID));
         claims.put(CLAIM_NAME, textNode(USER_NAME));
         claims.put(CLAIM_EMAIL, textNode(USER_EMAIL));
+        claims.put(CLAIM_ACCOUNT, textNode(USER_ACCOUNT));
         claims.put(CLAIM_ROLES, textNode(USER_APP_ROLES));
         claims.put(CLAIM_GROUPS, textNode(USER_GROUPS));
         claims.put(CLAIM_ORGS, textNode(USER_ORGANISATIONS));
@@ -156,6 +159,7 @@ class UserInfoExtractorTest {
                 CLAIM_SUB,
                 CLAIM_NAME,
                 CLAIM_EMAIL,
+                CLAIM_ACCOUNT,
                 CLAIM_ROLES,
                 CLAIM_GROUPS,
                 CLAIM_ORGS,


### PR DESCRIPTION
With extraction from JWT following Spring's converter pattern. Account is NOT exposed as `Optional` despite being nullable as intent is for account to become mandatory after initial rollout.