### PR TITLE
Fix support of JSON object organisation profiles

### DIFF
--- a/src/main/java/app/quickcase/sdk/spring/auth/converters/JsonUserInfoConverter.java
+++ b/src/main/java/app/quickcase/sdk/spring/auth/converters/JsonUserInfoConverter.java
@@ -47,18 +47,18 @@ public class JsonUserInfoConverter implements Converter<ObjectNode, UserInfo> {
     }
 
     @NonNull
-    private Optional<String> extractOptionalString(JsonNode claims, String claimName) {
+    private Optional<JsonNode> extractClaim(ObjectNode claims, String claimName) {
         if (!claims.has(claimName)) {
             return Optional.empty();
         }
 
-        var valueNode = claims.get(claimName);
+        return Optional.of(claims.get(claimName));
+    }
 
-        if (!valueNode.isTextual()) {
-            return Optional.empty();
-        }
-
-        return Optional.of(valueNode.asText());
+    @NonNull
+    private Optional<String> extractOptionalString(ObjectNode claims, String claimName) {
+        return extractClaim(claims, claimName).filter(JsonNode::isTextual)
+                                              .map(JsonNode::asText);
     }
 
     @NonNull
@@ -86,21 +86,31 @@ public class JsonUserInfoConverter implements Converter<ObjectNode, UserInfo> {
     private Map<String, OrganisationProfile> extractProfiles(String subject, ObjectNode claims) {
         log.debug("Extracting organisation profiles for subject `{}`", subject);
 
-        var organisationStr = extractOptionalString(claims, claimNames.organisations());
-
-        if (organisationStr.isEmpty()) {
-            return Map.of();
-        }
-
-        try {
-            return ORG_PARSER.parse(MAPPER.readTree(organisationStr.get()));
-        } catch (JsonProcessingException e) {
-            log.warn(
-                    "Failed to parse JSON object for claim `{}`, got: `{}`",
-                    claimNames.organisations(),
-                    organisationStr.get()
-            );
-            return Map.of();
-        }
+        return extractClaim(claims, claimNames.organisations()).map(this::parseProfiles)
+                                                               .orElse(Map.of());
     }
+
+    @NonNull
+    private Map<String, OrganisationProfile> parseProfiles(JsonNode organisationNode) {
+        if (organisationNode.isObject()) {
+            return ORG_PARSER.parse(organisationNode);
+        }
+
+        if (organisationNode.isTextual()) {
+            try {
+                return ORG_PARSER.parse(MAPPER.readTree(organisationNode.asText()));
+            } catch (JsonProcessingException e) {
+                log.warn(
+                        "Failed to parse organisation profiles from JSON object for claim `{}`",
+                        claimNames.organisations(),
+                        e
+                );
+                return Map.of();
+            }
+        }
+
+        log.warn("Failed to parse organisation profiles: Unsupported JSON node {}", organisationNode);
+        return Map.of();
+    }
+
 }

--- a/src/test/java/app/quickcase/sdk/spring/auth/converters/JsonUserInfoConverterTest.java
+++ b/src/test/java/app/quickcase/sdk/spring/auth/converters/JsonUserInfoConverterTest.java
@@ -10,6 +10,7 @@ import app.quickcase.sdk.spring.auth.organisation.OrganisationProfile;
 import app.quickcase.sdk.spring.auth.userinfo.UserInfo;
 import app.quickcase.sdk.spring.auth.userinfo.UserPreferences;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -100,8 +101,8 @@ class JsonUserInfoConverterTest {
     }
 
     @Test
-    @DisplayName("should extract organisation profiles")
-    void shouldExtractOrganisationProfiles() {
+    @DisplayName("should extract organisation profiles from JSON string")
+    void shouldExtractOrganisationProfilesFromJsonString() {
         var json = JSON.objectNode()
                        .put(SUB_CLAIM, "sub-123")
                        .put(ORGANISATIONS_CLAIMS, """
@@ -117,6 +118,48 @@ class JsonUserInfoConverterTest {
                                  }
                                }
                                """);
+
+        when(claimNamesProvider.organisations()).thenReturn(ORGANISATIONS_CLAIMS);
+
+        var userInfo = converter.convert(json);
+
+        assertThat(userInfo.getOrganisationProfiles(), equalTo(
+                Map.of(
+                        "org1", OrganisationProfile.builder()
+                                                   .accessLevel(AccessLevel.ORGANISATION)
+                                                   .securityClassification(SecurityClassification.PRIVATE)
+                                                   .build(),
+                        "org2", OrganisationProfile.builder()
+                                                   .accessLevel(AccessLevel.GROUP)
+                                                   .group("group1")
+                                                   .securityClassification(SecurityClassification.PUBLIC)
+                                                   .build()
+                )
+        ));
+    }
+
+    @Test
+    @DisplayName("should extract organisation profiles from JSON object")
+    void shouldExtractOrganisationProfilesFromJsonObject() {
+        var json = JSON.objectNode()
+                       .put(SUB_CLAIM, "sub-123")
+                       .<ObjectNode>set(
+                               ORGANISATIONS_CLAIMS,
+                               JSON.objectNode()
+                                   .<ObjectNode>set(
+                                           "org1",
+                                           JSON.objectNode()
+                                               .put("access", "ORGANISATION")
+                                               .put("classification", "PRIVATE")
+                                   )
+                                   .<ObjectNode>set(
+                                           "org2",
+                                           JSON.objectNode()
+                                               .put("access", "GROUP")
+                                               .put("group", "group1")
+                                               .put("classification", "PUBLIC")
+                                   )
+                       );
 
         when(claimNamesProvider.organisations()).thenReturn(ORGANISATIONS_CLAIMS);
 


### PR DESCRIPTION
User info endpoint might return organisation profiles directly as a JSON object instead of a JSON string. This fix detects this scenario and handle parsing accordingly.